### PR TITLE
Added check for "camel" option to makeLabel in BibtexKeyPatternUtil

### DIFF
--- a/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
+++ b/src/main/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtil.java
@@ -484,7 +484,7 @@ public class BibtexKeyPatternUtil {
                     Optional<Formatter> formatter = Formatters.getFormatterForModifier(modifier);
                     if (formatter.isPresent()) {
                         resultingLabel = formatter.get().format(label);
-                    } else if (!modifier.isEmpty() && modifier.length()>= 2 && (modifier.charAt(0) == '(') && modifier.endsWith(")")) {
+                    } else if (!modifier.isEmpty() && (modifier.length()>= 2) && (modifier.charAt(0) == '(') && modifier.endsWith(")")) {
                         // Alternate text modifier in parentheses. Should be inserted if
                         // the label is empty:
                         if (label.isEmpty() && (modifier.length() > 2)) {
@@ -640,6 +640,8 @@ public class BibtexKeyPatternUtil {
                                 Collections.singletonList("abbr"), 0));
             } else if ("veryshorttitle".equals(val)) {
                 return getTitleWords(1, entry.getField(FieldName.TITLE).orElse(""));
+            } else if ("camel".equals(val)) {
+                return getCamelizedTitle(entry.getField(FieldName.TITLE).orElse(""));
             } else if ("shortyear".equals(val)) {
                 String yearString = entry.getFieldOrAlias(FieldName.YEAR).orElse("");
                 if (yearString.isEmpty()) {
@@ -754,6 +756,47 @@ public class BibtexKeyPatternUtil {
             }
             stringBuilder.append(word);
             words++;
+        }
+
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Capitalises and concatenates the words out of the "title" field in the given BibTeX entry
+     */
+    public static String getCamelizedTitle(String title) {
+        return keepLettersAndDigitsOnly(getCamelizedTitleWithSpaces(title));
+    }
+
+    private static String getCamelizedTitleWithSpaces(String title) {
+        String ss = new RemoveLatexCommandsFormatter().format(title);
+        StringBuilder stringBuilder = new StringBuilder();
+        StringBuilder current;
+        int piv = 0;
+
+        // sorry for being English-centric. I guess these
+        // words should really be an editable preference.
+        while (piv < ss.length()) {
+            current = new StringBuilder();
+            // Get the next word:
+            while ((piv < ss.length()) && !Character.isWhitespace(ss.charAt(piv))
+                    && (ss.charAt(piv) != '-')) {
+                current.append(ss.charAt(piv));
+                piv++;
+            }
+            piv++;
+            // Check if it is ok:
+            String word = current.toString().trim();
+            if (word.isEmpty()) {
+                continue;
+            }
+            word = word.substring(0, 1).toUpperCase() + word.substring(1);
+
+            // If we get here, the word was accepted.
+            if (stringBuilder.length() > 0) {
+                stringBuilder.append(' ');
+            }
+            stringBuilder.append(word);
         }
 
         return stringBuilder.toString();

--- a/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
+++ b/src/test/java/org/jabref/logic/bibtexkeypattern/BibtexKeyPatternUtilTest.java
@@ -640,7 +640,7 @@ public class BibtexKeyPatternUtilTest {
      */
     @Test
     public void shortTitle() {
-        // veryShortTitle is getTitleWords with "3" as count
+        // shortTitle is getTitleWords with "3" as count
         int count = 3;
         assertEquals("applicationmigrationeffort",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
@@ -657,6 +657,31 @@ public class BibtexKeyPatternUtilTest {
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
         assertEquals("MeasurementDesignTime",
                 BibtexKeyPatternUtil.getTitleWords(count, TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
+    }
+
+    /**
+     * Tests [camel]
+     */
+    @Test
+    public void camel() {
+        // camel capitalises and concatenates all the words of the title
+        assertEquals("ApplicationMigrationEffortInTheCloudTheCaseOfCloudPlatforms",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_ALL_LOWER_FOUR_SMALL_WORDS_ONE_EN_DASH));
+        assertEquals("BPELConformanceInOpenSourceEnginesTheCaseOfStaticAnalysis",
+                BibtexKeyPatternUtil.getCamelizedTitle(
+                TITLE_STRING_ALL_LOWER_FIRST_WORD_IN_BRACKETS_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+        assertEquals("ProcessViewingPatterns", BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED));
+        assertEquals("BPMNConformanceInOpenSourceEngines",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_ONE_UPPER_WORD_ONE_SMALL_WORD));
+        assertEquals("TheDifferenceBetweenGraphBasedAndBlockStructuredBusinessProcessModellingLanguages",
+                BibtexKeyPatternUtil.getCamelizedTitle(
+                TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AT_THE_BEGINNING));
+        assertEquals("CloudComputingTheNextRevolutionInIT",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_TWO_SMALL_WORDS_SMALL_WORD_AFTER_COLON));
+        assertEquals("TowardsChoreographyBasedProcessDistributionInTheCloud",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_TWO_SMALL_WORDS_ONE_CONNECTED_WORD));
+        assertEquals("OnTheMeasurementOfDesignTimeAdaptabilityForProcessBasedSystems",
+                BibtexKeyPatternUtil.getCamelizedTitle(TITLE_STRING_CASED_FOUR_SMALL_WORDS_TWO_CONNECTED_WORDS));
     }
 
     @Test


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, ... -->
In https://github.com/JabRef/jabref/issues/2589 it was discovered that the there is no check in the makeLabel function for the [camel] option. 
I've added the check and have written some tests for the use case.

- [ ] Change in CHANGELOG.md described
- [X] Tests created for changes
- [ ] Screenshots added (for bigger UI changes)
- [X] Manually tested changed features in running JabRef
- [ ] Check documentation status (Issue created for outdated help page at [help.jabref.org](https://github.com/JabRef/help.jabref.org/issues)?)
- [ ] If you changed the localization: Did you run `gradle localizationUpdate`?
